### PR TITLE
Change kotlin version to 1.1.2-4

### DIFF
--- a/kotlinApp/app/build.gradle
+++ b/kotlinApp/app/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.1.2-3'
+        kotlin_version = '1.1.2-4'
     }
     repositories {
         jcenter()


### PR DESCRIPTION
This fixes an error that throws an exception:

java.lang.NoSuchMethodError: com.android.build.gradle.internal.variant.BaseVariantData.getOutputs()Ljava/util/List;

while syncing using gradle plugin 3.0.0-alpha5

1.1.2-3 is not compatible with 3.0.0-alpha5