### PR TITLE
Migrate to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -43,12 +43,14 @@ android {
 
 dependencies {
     // Support Libraries
-    compile "com.android.support:appcompat-v7:$supportLibVersion"
-    compile "com.android.support:support-emoji:$supportLibVersion"
-    compile "com.android.support:support-emoji-appcompat:$supportLibVersion"
-    compile "com.android.support:support-emoji-bundled:$supportLibVersion"
+    compile 'androidx.appcompat:appcompat:1.0.0'
+    compile 'androidx.emoji:emoji:1.0.0'
+    compile 'androidx.emoji:emoji-appcompat:1.0.0'
+    compile 'androidx.emoji:emoji-bundled:1.0.0'
 
     // Test
     testCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.0'
+    androidTestCompile 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,10 +16,6 @@
 
 apply plugin: 'com.android.application'
 
-ext {
-    supportLibVersion = '28.0.0'
-}
-
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -35,9 +31,6 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
-    }
-    configurations.all {
-        resolutionStrategy.force "com.android.support:support-annotations:$supportLibVersion"
     }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,16 +17,15 @@
 apply plugin: 'com.android.application'
 
 ext {
-    supportLibVersion = '26.0.0'
+    supportLibVersion = '28.0.0'
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.0"
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.example.android.emojicompat"
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,5 +52,4 @@ dependencies {
     testCompile 'junit:junit:4.12'
     androidTestCompile 'androidx.test.espresso:espresso-core:3.1.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
 }

--- a/app/src/androidTest/java/com/example/android/emojicompat/MainActivityTest.java
+++ b/app/src/androidTest/java/com/example/android/emojicompat/MainActivityTest.java
@@ -16,15 +16,15 @@
 
 package com.example.android.emojicompat;
 
-import static android.support.test.espresso.Espresso.onView;
-import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-import android.support.annotation.StringRes;
-import android.support.test.filters.MediumTest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.runner.AndroidJUnit4;
+import androidx.annotation.StringRes;
+import androidx.test.filters.MediumTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/app/src/main/java/com/example/android/emojicompat/CustomTextView.java
+++ b/app/src/main/java/com/example/android/emojicompat/CustomTextView.java
@@ -17,9 +17,9 @@
 package com.example.android.emojicompat;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
-import android.support.text.emoji.widget.EmojiTextViewHelper;
-import android.support.v7.widget.AppCompatTextView;
+import androidx.annotation.Nullable;
+import androidx.emoji.widget.EmojiTextViewHelper;
+import androidx.appcompat.widget.AppCompatTextView;
 import android.text.InputFilter;
 import android.util.AttributeSet;
 

--- a/app/src/main/java/com/example/android/emojicompat/MainActivity.java
+++ b/app/src/main/java/com/example/android/emojicompat/MainActivity.java
@@ -18,12 +18,12 @@ package com.example.android.emojicompat;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.text.emoji.EmojiCompat;
-import android.support.text.emoji.FontRequestEmojiCompatConfig;
-import android.support.text.emoji.bundled.BundledEmojiCompatConfig;
-import android.support.v4.provider.FontRequest;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.Nullable;
+import androidx.emoji.text.EmojiCompat;
+import androidx.emoji.text.FontRequestEmojiCompatConfig;
+import androidx.emoji.bundled.BundledEmojiCompatConfig;
+import androidx.core.provider.FontRequest;
+import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.widget.TextView;
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,21 +30,21 @@
         android:orientation="vertical"
         android:padding="@dimen/spacing_normal">
 
-        <android.support.text.emoji.widget.EmojiAppCompatTextView
+        <androidx.emoji.widget.EmojiAppCompatTextView
             android:id="@+id/emoji_text_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:textSize="@dimen/text_size"/>
 
-        <android.support.text.emoji.widget.EmojiAppCompatEditText
+        <androidx.emoji.widget.EmojiAppCompatEditText
             android:id="@+id/emoji_edit_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:textSize="@dimen/text_size"/>
 
-        <android.support.text.emoji.widget.EmojiAppCompatButton
+        <androidx.emoji.widget.EmojiAppCompatButton
             android:id="@+id/emoji_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/kotlinApp/app/build.gradle
+++ b/kotlinApp/app/build.gradle
@@ -29,10 +29,6 @@ buildscript {
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
-ext {
-    supportLibVersion = '28.0.0'
-}
-
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -41,7 +37,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -49,21 +45,19 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    configurations.all {
-        resolutionStrategy.force "com.android.support:support-annotations:$supportLibVersion"
-    }
 }
 
 dependencies {
     // Support Libraries
-    compile "com.android.support:appcompat-v7:$supportLibVersion"
-    compile "com.android.support:support-emoji:$supportLibVersion"
-    compile "com.android.support:support-emoji-appcompat:$supportLibVersion"
-    compile "com.android.support:support-emoji-bundled:$supportLibVersion"
+    compile 'androidx.appcompat:appcompat:1.0.0'
+    compile 'androidx.emoji:emoji:1.0.0'
+    compile 'androidx.emoji:emoji-appcompat:1.0.0'
+    compile 'androidx.emoji:emoji-bundled:1.0.0'
 
     // Test
     testCompile 'junit:junit:4.12'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+    androidTestCompile 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.test:rules:1.2.0'
 
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/kotlinApp/app/build.gradle
+++ b/kotlinApp/app/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     ext {
-        kotlin_version = '1.1.3-2'
+        kotlin_version = '1.3.41'
     }
     repositories {
         jcenter()
@@ -30,16 +30,15 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 ext {
-    supportLibVersion = '26.0.0'
+    supportLibVersion = '28.0.0'
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.0'
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.example.android.emojicompat"
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/kotlinApp/app/src/androidTest/java/com/example/android/emojicompat/MainActivityTest.kt
+++ b/kotlinApp/app/src/androidTest/java/com/example/android/emojicompat/MainActivityTest.kt
@@ -16,13 +16,13 @@
 
 package com.example.android.emojicompat
 
-import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
-import android.support.test.espresso.matcher.ViewMatchers.withText
-import android.support.test.filters.MediumTest
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.filters.MediumTest
+import androidx.test.rule.ActivityTestRule
+import androidx.test.runner.AndroidJUnit4
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/kotlinApp/app/src/main/java/com/example/android/emojicompat/CustomTextView.kt
+++ b/kotlinApp/app/src/main/java/com/example/android/emojicompat/CustomTextView.kt
@@ -17,8 +17,8 @@
 package com.example.android.emojicompat
 
 import android.content.Context
-import android.support.text.emoji.widget.EmojiTextViewHelper
-import android.support.v7.widget.AppCompatTextView
+import androidx.emoji.widget.EmojiTextViewHelper
+import androidx.appcompat.widget.AppCompatTextView
 import android.text.InputFilter
 import android.util.AttributeSet
 

--- a/kotlinApp/app/src/main/java/com/example/android/emojicompat/EmojiCompatApplication.kt
+++ b/kotlinApp/app/src/main/java/com/example/android/emojicompat/EmojiCompatApplication.kt
@@ -17,10 +17,10 @@
 package com.example.android.emojicompat
 
 import android.app.Application
-import android.support.text.emoji.EmojiCompat
-import android.support.text.emoji.FontRequestEmojiCompatConfig
-import android.support.text.emoji.bundled.BundledEmojiCompatConfig
-import android.support.v4.provider.FontRequest
+import androidx.emoji.text.EmojiCompat
+import androidx.emoji.bundled.BundledEmojiCompatConfig
+import androidx.emoji.text.FontRequestEmojiCompatConfig
+import androidx.core.provider.FontRequest
 import android.util.Log
 
 

--- a/kotlinApp/app/src/main/java/com/example/android/emojicompat/MainActivity.kt
+++ b/kotlinApp/app/src/main/java/com/example/android/emojicompat/MainActivity.kt
@@ -17,8 +17,8 @@
 package com.example.android.emojicompat
 
 import android.os.Bundle
-import android.support.text.emoji.EmojiCompat
-import android.support.v7.app.AppCompatActivity
+import androidx.emoji.text.EmojiCompat
+import androidx.appcompat.app.AppCompatActivity
 import android.widget.TextView
 import java.lang.ref.WeakReference
 

--- a/kotlinApp/app/src/main/res/layout/activity_main.xml
+++ b/kotlinApp/app/src/main/res/layout/activity_main.xml
@@ -30,21 +30,21 @@
         android:orientation="vertical"
         android:padding="@dimen/spacing_normal">
 
-        <android.support.text.emoji.widget.EmojiAppCompatTextView
+        <androidx.emoji.widget.EmojiAppCompatTextView
             android:id="@+id/emoji_text_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:textSize="@dimen/text_size"/>
 
-        <android.support.text.emoji.widget.EmojiAppCompatEditText
+        <androidx.emoji.widget.EmojiAppCompatEditText
             android:id="@+id/emoji_edit_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/spacing_small"
             android:textSize="@dimen/text_size"/>
 
-        <android.support.text.emoji.widget.EmojiAppCompatButton
+        <androidx.emoji.widget.EmojiAppCompatButton
             android:id="@+id/emoji_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/kotlinApp/build.gradle
+++ b/kotlinApp/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 }
 

--- a/kotlinApp/build.gradle
+++ b/kotlinApp/build.gradle
@@ -17,6 +17,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'

--- a/kotlinApp/gradle.properties
+++ b/kotlinApp/gradle.properties
@@ -9,6 +9,8 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/kotlinApp/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlinApp/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
It has been a while since this repo has been updates

- Up target SDK to 28
- Move to AndroidX
- Update Kotlin version
- [Use `jdk` instead of the old `jre` version of Kotlin stdlib](https://stackoverflow.com/questions/50344635/kotlin-stdlib-jre7-is-deprecated-please-use-kotlin-stdlib-jdk7-instead)
- Update Gradle version
- Update AGP version